### PR TITLE
modified logistics app

### DIFF
--- a/farmdine/settings.py
+++ b/farmdine/settings.py
@@ -44,6 +44,7 @@ INSTALLED_APPS = [
     'products',
     'likes',
     'comments',
+    'logistics',
 ]
 
 MIDDLEWARE = [

--- a/logistics/models.py
+++ b/logistics/models.py
@@ -1,3 +1,23 @@
 from django.db import models
+from order.models import Order
+import uuid
 
-# Create your models here.
+
+class Logistics(models.Model):
+    PENDING = 'Pending'
+    IN_TRANSIT = 'In Transit'
+    DELIVERED = 'Delivered'
+    STATUS_CHOICES = [
+        (PENDING, 'Pending'),
+        (IN_TRANSIT, 'In Transit'),
+        (DELIVERED, 'Delivered'),
+    ]
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    order = models.OneToOneField(Order, on_delete=models.CASCADE, related_name='logistics')
+    status = models.CharField(max_length=20, choices=STATUS_CHOICES, default=PENDING)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    def __str__(self):
+        return f'{self.order.id} - {self.status}'
+

--- a/logistics/serializers.py
+++ b/logistics/serializers.py
@@ -1,7 +1,8 @@
 from rest_framework import serializers
-from orders.models import Order
+from .models import Logistics
 
-class OrderSerializer(serializers.ModelSerializer):
+
+class LogisticsSerializer(serializers.ModelSerializer):
     class Meta:
-        model = Order
-        fields = ['order_id', 'status', 'created_at', 'updated_at']
+        model = Logistics
+        fields = ['id', 'order', 'status', 'updated_at']

--- a/logistics/urls.py
+++ b/logistics/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
-from .views import OrderDetailView
+from .views import get_logistics_details, update_logistics_status
 
 urlpatterns = [
-    path('orders/<str:order_id>/', OrderDetailView.as_view(), name='order-detail'),
+    path('logistics/<uuid:order_id>/', get_logistics_details, name='get_logistics_details'),
+    path('logistics/<uuid:order_id>/status/', update_logistics_status, name='update_logistics_status'),
 ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
​
## Description
Implemented the `logistics` Api, which provides functionality to track and manage order statuses.
​
## Related Issue (Link to linear ticket)
https://linear.app/internpulse/issue/INT-86/logistics
​
## Motivation and Context
This change is required to implement order tracking and status management functionality within the `logistics` app. It solves the problem of tracking order statuses such as in `pending`, `in transit`, and `done` by providing endpoints to retrieve and update these statuses.
​
## How Has This Been Tested?
Created test cases in `logistics/tests.py` to verify the functionality of retrieving and updating order statuses.

### Manual Tests include:
-Retrieving an order by its ID and checking the status.
` curl -X GET http://127.0.0.1:8000/api/logistics/<order_id>/ -H "Authorization: Token <your_token>" `

-Updating the status of an order and verifying the change.
` curl -X PUT http://127.0.0.1:8000/api/logistics/<order_id>/status/ -H "Authorization: Token <your_token>" -d '{"status": "In Transit"}' -H "Content-Type: application/json" `
​
## Screenshots (if appropriate - Postman, etc):
​
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
